### PR TITLE
Bluesky widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@iktakahiro/markdown-it-katex": "^4.0.0",
     "angular-archwizard": "^7.0.0",
     "angular2-query-builder": "^0.6.2",
+    "bsky-embed": "^0.2.0",
     "complexviewer": "2.2.1",
     "core-js": "^2.4.1",
     "cytoscape": "^3.9.1",

--- a/src/app/home-dashboard/featured-dataset/featured-dataset.component.html
+++ b/src/app/home-dashboard/featured-dataset/featured-dataset.component.html
@@ -1,10 +1,10 @@
-<div id="dataset" class="margin-top-large" *ngIf="dataset$ | async as dataset">
-    <h4 id="feature-dataset-title" class="margin-bottom-large">
+<div id="dataset" class="margin-top-medium" *ngIf="dataset$ | async as dataset">
+    <h4 id="feature-dataset-title">
         <i class="icon icon-generic" data-icon="D"></i> Featured Dataset
     </h4>
 
     <div *ngIf="dataset.pubmeds[0] as firstPubMed">
-        <div class="text-justify margin-bottom-large">
+        <div class="text-justify margin-bottom-medium">
             {{dataset.title}} -
 
             <b *ngIf="isReleased(firstPubMed); else link;">

--- a/src/app/home-dashboard/home-dashboard.component.html
+++ b/src/app/home-dashboard/home-dashboard.component.html
@@ -16,9 +16,6 @@
 
     <div class="columns medium-3">
       <div class="columns medium-10">
-        <div class="row margin-top-large">
-          <ip-newsletter-subscription></ip-newsletter-subscription>
-        </div>
         <div class="row">
             <ip-featured-dataset></ip-featured-dataset>
         </div>
@@ -27,6 +24,9 @@
         </div>
       <div class="row">
           <ip-twitter-display></ip-twitter-display>
+      </div>
+      <div class="row">
+          <ip-newsletter-subscription></ip-newsletter-subscription>
       </div>
       </div>
     </div>

--- a/src/app/home-dashboard/home-dashboard.module.ts
+++ b/src/app/home-dashboard/home-dashboard.module.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import {NgModule, CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {HomeDescriptionComponent} from './home-description/home-description.component';
 import {TileMenuComponent} from './tile-menu/tile-menu.component';
@@ -80,7 +80,8 @@ import { BooleanInputComponent } from './advanced-search/boolean-input/boolean-i
     RangeInputComponent,
     DateRangeComponent,
     BooleanInputComponent
-  ]
+  ],
+  schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
 })
 export class HomeDashboardModule {
 }

--- a/src/app/home-dashboard/news/news.component.html
+++ b/src/app/home-dashboard/news/news.component.html
@@ -1,13 +1,13 @@
-<div id="news" class="margin-top-large">
-    <h4 class="margin-bottom-large">
+<div id="news" class="margin-top-medium">
+    <h4>
         <i class="icon icon-generic" data-icon="N"></i> Latest News
     </h4>
 
-    <div id="releaseVersion" class="margin-top-medium padding-top-medium padding-left-medium padding-right-medium">
+    <div id="releaseVersion" class="padding-left-medium padding-right-medium">
         <h6><i class="icon icon-common icon-cogs"></i> IntAct Portal version: {{version}} - {{releaseDate}}</h6>
 
         <h6 *ngIf="release"><i class="icon icon-common icon-database"></i> {{release}}</h6>
-        <ul *ngIf="summary">
+        <ul *ngIf="summary" style="margin-bottom: 0">
             <li>Publications : {{summary['Publications'] | number}}</li>
             <li>Interactors : {{summary['Interactors'] | number }}</li>
             <li>Interactions : {{summary['Interactions'] | number }}</li>

--- a/src/app/home-dashboard/twitter-display/twitter-display.component.html
+++ b/src/app/home-dashboard/twitter-display/twitter-display.component.html
@@ -4,7 +4,7 @@
     Social Media
   </h4>
 
-  <bsky-embed username="ebi.embl.org" custom-styles="
+  <bsky-embed username="intact-ebi.bsky.social" custom-styles="
         img[alt='profile picture'] {
             display: none;
         }

--- a/src/app/home-dashboard/twitter-display/twitter-display.component.html
+++ b/src/app/home-dashboard/twitter-display/twitter-display.component.html
@@ -1,9 +1,26 @@
 <div id="twitter" class="margin-top-large">
   <h4>
-    <a href="https://twitter.com/intact_project" target="_blank" matTooltip="Follow us" matTooltipPosition="left">
-      <i id="twitter-logo" class="icon icon-socialmedia" data-icon="T"></i>
-    </a> Tweets
+    <i class="icon icon-common icon-external-systems"></i>
+    Social Media
   </h4>
+
+  <bsky-embed username="ebi.embl.org" custom-styles="
+        section {
+            align-items: baseline;
+            max-height: 406px;
+            overflow-y: overlay;
+            overflow-x: clip;
+            box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.3);
+        }
+
+        .p-4 {
+            padding: 0.75rem;
+        }
+
+        .max-w-screen-sm {
+            min-width: 280px;
+        }
+  "></bsky-embed>
 
   <div class="margin-top-large margin-bottom-large">
     <a href="https://twitter.com/intact_project?ref_src=twsrc%5Etfw"
@@ -12,13 +29,5 @@
        data-show-count="false">
       Follow @intact_project
     </a>
-<!--    <a class="twitter-timeline"-->
-<!--       data-lang="en"-->
-<!--       data-height="300"-->
-<!--       data-theme="light"-->
-<!--       data-chrome="nofooter noheader noborders"-->
-<!--       data-link-color="#007c82"-->
-<!--       href="https://twitter.com/intact_project">-->
-<!--      Tweets by IntAct</a>-->
   </div>
 </div>

--- a/src/app/home-dashboard/twitter-display/twitter-display.component.html
+++ b/src/app/home-dashboard/twitter-display/twitter-display.component.html
@@ -1,4 +1,4 @@
-<div id="twitter" class="margin-top-large">
+<div id="twitter" class="margin-top-medium">
   <h4>
     <i class="icon icon-common icon-external-systems"></i>
     Social Media
@@ -26,7 +26,7 @@
         }
   "></bsky-embed>
 
-  <div class="margin-top-large margin-bottom-large">
+  <div class="margin-top-medium">
     <a href="https://twitter.com/intact_project?ref_src=twsrc%5Etfw"
        class="twitter-follow-button"
        data-size="large"

--- a/src/app/home-dashboard/twitter-display/twitter-display.component.html
+++ b/src/app/home-dashboard/twitter-display/twitter-display.component.html
@@ -5,6 +5,10 @@
   </h4>
 
   <bsky-embed username="ebi.embl.org" custom-styles="
+        img[alt='profile picture'] {
+            display: none;
+        }
+
         section {
             align-items: baseline;
             max-height: 406px;

--- a/src/app/home-dashboard/twitter-display/twitter-display.component.ts
+++ b/src/app/home-dashboard/twitter-display/twitter-display.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import 'bsky-embed/dist/bsky-embed.es.js';
 
 const twitterURL = 'https://platform.twitter.com/widgets.js';
 

--- a/src/app/interactions/shared/service/table-factory.service.ts
+++ b/src/app/interactions/shared/service/table-factory.service.ts
@@ -249,7 +249,6 @@ export class TableFactoryService {
 
   cvRender = (identifierColumn: string) => (data: any, type: any, row: any, meta: any, i?: number) => {
     let miId = row[identifierColumn];
-    console.log(i, miId[i], miId)
     if (i !== undefined) {
       miId = miId[i];
     }


### PR DESCRIPTION
Adding Bluesky widget to IntAct Portal.

Draft PR as IntAct Bluesky account is currently empty as we haven't imported the history from twitter there yet, so I have used the EMBL-EBI account to test the widget. You can check it out here https://intact-portal.github.io/intact-portal-view/home

Because the sidebar in IntAct Portal is wider than in Complex Portal we don't need a max width, we can let the width on auto and adapt the width of the widget to the width of the side panel. I have added a min width so if the window is make smaller to the point that the sidebar is skinny we don't end up with a really skinny unreadable widget.