### PR TITLE
Add custom data protection message with link to intact privacy notice

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -112,6 +112,15 @@
 </div>
 <!-- End suggested layout containers / #content -->
 
+<!-- EBI data protection banner -->
+<div id="data-protection-message-configuration"
+     data-message="This website requires cookies, and the limited processing of your personal data in order to function.
+      By using the site you are agreeing to this as outlined in our
+      <a class='white-color' href='https://raw.githubusercontent.com/intact-portal/intact-portal-documentation/master/assets/IntAct-and-Complex-Portal-websites-privacy-notice.pdf'>Privacy Notice</a>
+      and <a class='white-color' href='https://www.ebi.ac.uk/about/terms-of-use'>Terms of Use</a>."
+     data-service-id="intact-and-complex-portal-websites" data-data-protection-version="0.1">
+</div>
+
 <footer>
   <!--<script src="assets/html/global-footer.html"></script>-->
   <div id="global-footer" class="global-footer">


### PR DESCRIPTION
Required as the old system for privacy notices is being deprecated by the end of April. This is a temporary solution (recommended by the migration guide) until we migrate to the new system.